### PR TITLE
Resolve the ClassNotFoundException

### DIFF
--- a/features/org.wso2.carbon.appmgt.mdm.osgiconnector.feature/pom.xml
+++ b/features/org.wso2.carbon.appmgt.mdm.osgiconnector.feature/pom.xml
@@ -72,7 +72,6 @@
                             </adviceFile>
                             <bundles>
                                 <bundleDef>org.wso2.carbon.appmgt:org.wso2.carbon.appmgt.mdm.osgiconnector:${carbon.appmgt.version}</bundleDef>
-                                <bundleDef>org.bouncycastle.wso2:bcprov-jdk15on:${bcprov.wso2.version}</bundleDef>
                                 <bundleDef>com.googlecode.plist:dd-plist:${googlecode.plist.version}</bundleDef>
                             </bundles>
                             <importFeatures>

--- a/features/org.wso2.carbon.appmgt.mdm.restconnector.feature/pom.xml
+++ b/features/org.wso2.carbon.appmgt.mdm.restconnector.feature/pom.xml
@@ -67,7 +67,6 @@
                             </adviceFile>
                             <bundles>
 				<bundleDef>org.wso2.carbon.appmgt:org.wso2.carbon.appmgt.mdm.restconnector:${carbon.appmgt.version}</bundleDef>
-				<bundleDef>org.bouncycastle.wso2:bcprov-jdk15on:${bcprov.wso2.version}</bundleDef>
 				<bundleDef>com.googlecode.plist:dd-plist:${googlecode.plist.version}</bundleDef>
                             </bundles>
                             <importFeatures>

--- a/features/org.wso2.carbon.appmgt.mdm.wso2emm.feature/pom.xml
+++ b/features/org.wso2.carbon.appmgt.mdm.wso2emm.feature/pom.xml
@@ -66,7 +66,6 @@
                             </adviceFile>
                             <bundles>
 				<bundleDef>org.wso2.carbon.appmgt:org.wso2.carbon.appmgt.mdm.wso2emm:${carbon.appmgt.version}</bundleDef>
-				<bundleDef>org.bouncycastle.wso2:bcprov-jdk15on:${bcprov.wso2.version}</bundleDef>
 				<bundleDef>com.googlecode.plist:dd-plist:${googlecode.plist.version}</bundleDef>
                             </bundles>
                             <importFeatures>

--- a/features/org.wso2.carbon.appmgt.mobile/pom.xml
+++ b/features/org.wso2.carbon.appmgt.mobile/pom.xml
@@ -66,7 +66,6 @@
                             </adviceFile>
                             <bundles>
 				<bundleDef>org.wso2.carbon.appmgt:org.wso2.carbon.appmgt.mobile:${carbon.appmgt.version}</bundleDef>
-				<bundleDef>org.bouncycastle.wso2:bcprov-jdk15on:${bcprov.wso2.version}</bundleDef>
 				<bundleDef>com.googlecode.plist:dd-plist:${googlecode.plist.version}</bundleDef>
                             </bundles>
                             <importFeatures>

--- a/pom.xml
+++ b/pom.xml
@@ -817,8 +817,8 @@
     <es.feature.version>1.0.0</es.feature.version>
 
     <!-- Jaggery Version -->
-    <jaggery.js.version>0.12.5</jaggery.js.version>
-    <jaggery.version>0.12.5</jaggery.version>
+    <jaggery.js.version>0.12.6-SNAPSHOT</jaggery.js.version>
+    <jaggery.version>0.12.6-SNAPSHOT</jaggery.version>
     <jaggery.scxml.executors.version>1.4.0</jaggery.scxml.executors.version>
     <jaggeryjs.markdown.feature.version>1.0.0</jaggeryjs.markdown.feature.version>
     <jaggeryjs.caramel.feature.version>1.0.1</jaggeryjs.caramel.feature.version>
@@ -861,7 +861,6 @@
     <httpmime.version>4.3.6</httpmime.version>
     <jackson.version>1.4.0</jackson.version>
     <googlecode.plist.version>1.8</googlecode.plist.version>
-    <bcprov.wso2.version>1.49.wso2v1</bcprov.wso2.version>
 
     <javax.xml.soap.imp.pkg.version>[1.0.0, 1.1.0)</javax.xml.soap.imp.pkg.version>
     <javax.xml.stream.imp.pkg.version>[1.0.1, 1.1.0)</javax.xml.stream.imp.pkg.version>


### PR DESCRIPTION
There were two bouncy castle versions packed with the two different
features. That is the root cause for this. Removed the old one which
comes from AppM side.
