### PR TITLE
Fix for APPM-1598 , Fix the parsing error when the manifest.xml have white lines

### DIFF
--- a/components/org.wso2.carbon.appmgt.mobile/src/main/java/org/wso2/mobile/utils/utilities/AndroidXMLParsing.java
+++ b/components/org.wso2.carbon.appmgt.mobile/src/main/java/org/wso2/mobile/utils/utilities/AndroidXMLParsing.java
@@ -162,8 +162,7 @@ public class AndroidXMLParsing {
                 break;
 
             } else {
-
-                break;
+                off += 4;  //Skip the unidentified work
             }
         }
 


### PR DESCRIPTION
Please merge this to fix the issue.
