### PR TITLE
Fixes #1214

### DIFF
--- a/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/extensions/mobileapp/plist.jag
+++ b/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/extensions/mobileapp/plist.jag
@@ -6,7 +6,7 @@ matcher.match('/{context}/api/mobileapp/getplist/{tenantId}/{filename}');
 var tenantId = matcher.elements().tenantId;
 var fileName = matcher.elements().filename;
 var server = require('store').server;
-var registry = server.anonRegistry(tenantId);
+var registry = server.systemRegistry(tenantId);
 var caramel = require('caramel');
 var contextPath = caramel.configs().context;
 


### PR DESCRIPTION
Fixes https://github.com/wso2/product-iots/issues/1214. Published iOS application cannot be installed from the store when enabled visibility restriction.