### PR TITLE
APPM-1622 : Changing the RXT name for documentation

### DIFF
--- a/components/org.wso2.carbon.appmgt.impl/src/main/java/org/wso2/carbon/appmgt/impl/APIProviderImpl.java
+++ b/components/org.wso2.carbon.appmgt.impl/src/main/java/org/wso2/carbon/appmgt/impl/APIProviderImpl.java
@@ -1550,7 +1550,7 @@ class APIProviderImpl extends AbstractAPIManager implements APIProvider {
             }
 
             Association[] associations = registry.getAssociations(docPath,
-                                                                  AppMConstants.DOCUMENTATION_KEY);
+                                                                  AppMConstants.DOCUMENTATION_ASSOCIATION);
             for (Association association : associations) {
                 registry.delete(association.getDestinationPath());
             }

--- a/components/org.wso2.carbon.appmgt.impl/src/main/java/org/wso2/carbon/appmgt/impl/AppMConstants.java
+++ b/components/org.wso2.carbon.appmgt.impl/src/main/java/org/wso2/carbon/appmgt/impl/AppMConstants.java
@@ -57,7 +57,7 @@ public final class AppMConstants {
     //Association between documentation and its content
     public static final String DOCUMENTATION_CONTENT_ASSOCIATION = "hasContent";
 
-    public static final String DOCUMENTATION_KEY = "document";
+    public static final String DOCUMENTATION_KEY = "appmdocument";
     public static final String DOCUMENTATION_RESOURCE_MAP_DATA = "Data";
     public static final String DOCUMENTATION_RESOURCE_MAP_CONTENT_TYPE = "contentType";
     public static final String DOCUMENTATION_RESOURCE_MAP_NAME = "name";

--- a/features/org.wso2.carbon.appmgt.core.feature/src/main/resources/repository/resources/rxts/appm-documentation.rxt
+++ b/features/org.wso2.carbon.appmgt.core.feature/src/main/resources/repository/resources/rxts/appm-documentation.rxt
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<artifactType type="application/vnd.wso2-document+xml" shortName="document" singularLabel="Document" pluralLabel="Documents" hasNamespace="false" iconSet="3">
+<artifactType type="application/vnd.wso2-document+xml" shortName="appmdocument" singularLabel="Document" pluralLabel="Documents" hasNamespace="false" iconSet="3">
     <storagePath>/appmgt/applicationdata/provider/@{overview_apiBasePath}/documentation/@{overview_name}</storagePath>
     <nameAttribute>overview_name</nameAttribute>
     <ui>


### PR DESCRIPTION


## Purpose
> Avoiding the documentation registry path conflict with API Manager.

## Approach
> Changing the RXT's short name to a name which is different from the one used in API Manager

