### PR TITLE
This closes wso2/product-iots#1677

### DIFF
--- a/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/extensions/mobileapp/api/mobile_api_router.jag
+++ b/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/extensions/mobileapp/api/mobile_api_router.jag
@@ -49,7 +49,8 @@ require('/modules/publisher.js').exec(function(ctx) {
             var appVersion = attributes["overview_version"];
             var appProvider = attributes["overview_provider"];
             var appPlatform = attributes["overview_platform"];
-            path = "/_system/governance/mobileapps/" + appProvider + "/" + appPlatform + "/" + appName + "/"
+            path = "/_system/governance/mobileapps/" + appProvider + "/" + appPlatform + "/" + appName + "/" +
+                   appVersion;
             registry.remove(path);
             apiProvider.removeBinaryFilesFromStorage(fileNames);
             auditLog.writeLog(tenantId, username, "AssetDeleted", appType, "{providerName='" + appProvider +


### PR DESCRIPTION
## Purpose
> When we delete an application from the publisher, it hides some applications which already exist in the publisher portal and recent applications on the store portal. This fixes the app displaying issue on IoTS app manager.

## Goals
> This fix changes the app deletion logic. Therefore, Instead of deleting the collection of an application, delete only application resource.

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A