### PR TITLE
This closes wso2/product-iots#1698

### DIFF
--- a/components/org.wso2.carbon.appmgt.mobile/src/main/java/org/wso2/carbon/appmgt/mobile/utils/HostResolver.java
+++ b/components/org.wso2.carbon.appmgt.mobile/src/main/java/org/wso2/carbon/appmgt/mobile/utils/HostResolver.java
@@ -49,9 +49,7 @@ public class HostResolver {
             }
         }else if("%https%".equals(abbr) || "https".equals(abbr)){
             try {
-                host += "https://" + getServerHost() + ":" +
-                        CarbonUtils.getTransportPort(ConfigurationContextFactory.createDefaultConfigurationContext(), "https");
-
+                host += "https://" + getServerHost() + ":" + System.getProperty(MobileConfigurations.IOT_CORE_HTTPS_PORT);
             } catch (Exception e) {
                 log.error("Error occurred while getting host", e);
             }

--- a/components/org.wso2.carbon.appmgt.mobile/src/main/java/org/wso2/carbon/appmgt/mobile/utils/HostResolver.java
+++ b/components/org.wso2.carbon.appmgt.mobile/src/main/java/org/wso2/carbon/appmgt/mobile/utils/HostResolver.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.NetworkUtils;
 import org.apache.axis2.util.Utils;
+
 /**
  * Resolved host information
  */
@@ -34,26 +35,26 @@ public class HostResolver {
     private static final Log log = LogFactory.getLog(HostResolver.class);
     public static final String LOCALHOST = "localhost";
 
-    public static String getHost(String abbr){
+    public static String getHost(String abbr) {
 
         String host = "";
 
-        if("%http%".equals(abbr) || "http".equals(abbr)){
+        if ("%http%".equals(abbr) || "http".equals(abbr)) {
 
             try {
                 host += "http://" + getServerHost() + ":" +
                         CarbonUtils.getTransportPort(ConfigurationContextFactory.createDefaultConfigurationContext(), "http");
             } catch (Exception e) {
-               log.error("Error occurred while getting host", e);
-               log.debug("Error: " + e);
+                log.error("Error occurred while getting host", e);
+                log.debug("Error: " + e);
             }
-        }else if("%https%".equals(abbr) || "https".equals(abbr)){
+        } else if ("%https%".equals(abbr) || "https".equals(abbr)) {
             try {
                 host += "https://" + getServerHost() + ":" + System.getProperty(MobileConfigurations.IOT_CORE_HTTPS_PORT);
             } catch (Exception e) {
                 log.error("Error occurred while getting host", e);
             }
-        }else{
+        } else {
             host = abbr;
         }
 
@@ -61,7 +62,7 @@ public class HostResolver {
     }
 
 
-    public static String getHostWithHTTP(){
+    public static String getHostWithHTTP() {
 
         String host = "";
 

--- a/components/org.wso2.carbon.appmgt.mobile/src/main/java/org/wso2/carbon/appmgt/mobile/utils/MobileConfigurations.java
+++ b/components/org.wso2.carbon.appmgt.mobile/src/main/java/org/wso2/carbon/appmgt/mobile/utils/MobileConfigurations.java
@@ -64,6 +64,8 @@ public class MobileConfigurations {
     public final static String  IOS_PLIST_PATH = "IosPlistPath";
     public final static String  ENTERPRISE_OPERATIONS_ENABLED = "EnterpriseOperations_Enabled";
     public final static String  ENTERPRISE_OPERATIONS_AUTHORIZED_ROLE = "EnterpriseOperations_AuthorizedRole";
+    public final static String IOT_CORE_HTTPS_PORT = "iot.core.https.port";
+
 
 
     private MobileConfigurations(){

--- a/components/org.wso2.carbon.appmgt.mobile/src/main/java/org/wso2/carbon/appmgt/mobile/utils/MobileConfigurations.java
+++ b/components/org.wso2.carbon.appmgt.mobile/src/main/java/org/wso2/carbon/appmgt/mobile/utils/MobileConfigurations.java
@@ -56,19 +56,18 @@ public class MobileConfigurations {
     private static HashMap<String, String> activeMDMProperties;
     private static HashMap<String, String> mDMConfigs;
 
-    public final static String  ENABLED = "Enabled";
-    public final static String  ENABLE_SAMPLE_DEVICES = "EnableSampleDevices";
-    public final static String  APP_DOWNLOAD_URL_HOST = "AppDownloadURLHost";
-    public final static String  APP_GET_URL = "/store/api/mobileapp/getfile/";
-    public final static String  ACTIVE_MDM = "ActiveMDM";
-    public final static String  IOS_PLIST_PATH = "IosPlistPath";
-    public final static String  ENTERPRISE_OPERATIONS_ENABLED = "EnterpriseOperations_Enabled";
-    public final static String  ENTERPRISE_OPERATIONS_AUTHORIZED_ROLE = "EnterpriseOperations_AuthorizedRole";
+    public final static String ENABLED = "Enabled";
+    public final static String ENABLE_SAMPLE_DEVICES = "EnableSampleDevices";
+    public final static String APP_DOWNLOAD_URL_HOST = "AppDownloadURLHost";
+    public final static String APP_GET_URL = "/store/api/mobileapp/getfile/";
+    public final static String ACTIVE_MDM = "ActiveMDM";
+    public final static String IOS_PLIST_PATH = "IosPlistPath";
+    public final static String ENTERPRISE_OPERATIONS_ENABLED = "EnterpriseOperations_Enabled";
+    public final static String ENTERPRISE_OPERATIONS_AUTHORIZED_ROLE = "EnterpriseOperations_AuthorizedRole";
     public final static String IOT_CORE_HTTPS_PORT = "iot.core.https.port";
 
 
-
-    private MobileConfigurations(){
+    private MobileConfigurations() {
         XMLStreamReader parser = null;
         try {
             parser = XMLInputFactory.newInstance().createXMLStreamReader(new FileInputStream(CONFIG_FILE_PATH));
@@ -84,30 +83,29 @@ public class MobileConfigurations {
     }
 
 
-    public static MobileConfigurations getInstance(){
-        if(mobileConfigurations == null){
+    public static MobileConfigurations getInstance() {
+        if (mobileConfigurations == null) {
             mobileConfigurations = new MobileConfigurations();
         }
         return mobileConfigurations;
     }
 
     /**
-     *
      * @return list of active MDM properties
      */
-    public HashMap<String, String> getActiveMDMProperties(){
-        if(activeMDMProperties == null){
+    public HashMap<String, String> getActiveMDMProperties() {
+        if (activeMDMProperties == null) {
 
             OMElement mdmPropertiesElement = documentElement.getFirstChildWithName(mobileConfElement)
                     .getFirstChildWithName(new QName("MDMProperties"));
 
             Iterator<OMElement> iterator = mdmPropertiesElement.getChildElements();
-            while (iterator.hasNext()){
+            while (iterator.hasNext()) {
                 OMElement mdmElement = iterator.next();
-                if(getMDMConfigs().get(ACTIVE_MDM).equals(mdmElement.getAttributeValue(new QName("name")))){
+                if (getMDMConfigs().get(ACTIVE_MDM).equals(mdmElement.getAttributeValue(new QName("name")))) {
                     HashMap<String, String> properties = new HashMap<String, String>();
                     Iterator<OMElement> propertiesElement = mdmElement.getChildElements();
-                    while(propertiesElement.hasNext()){
+                    while (propertiesElement.hasNext()) {
                         OMElement propertyElement = propertiesElement.next();
                         properties.put(propertyElement.getAttributeValue(new QName("name")), propertyElement.getText());
                     }
@@ -121,18 +119,17 @@ public class MobileConfigurations {
     }
 
     /**
-     *
      * @return list of active MDM configurations
      */
-    public HashMap<String, String> getMDMConfigs(){
-        if(mDMConfigs == null){
+    public HashMap<String, String> getMDMConfigs() {
+        if (mDMConfigs == null) {
 
             OMElement mDMConfigsElement = documentElement.getFirstChildWithName(mobileConfElement)
                     .getFirstChildWithName(new QName("MDMConfig"));
             HashMap<String, String> configs = new HashMap<String, String>();
             Iterator<OMElement> iterator = mDMConfigsElement.getChildElements();
 
-            while(iterator.hasNext()){
+            while (iterator.hasNext()) {
                 OMElement propertyElement = iterator.next();
                 configs.put(propertyElement.getAttributeValue(new QName("name")), propertyElement.getText());
             }
@@ -143,28 +140,25 @@ public class MobileConfigurations {
     }
 
     /**
-     *
      * @return the bundle id of the active MDM
      */
-    public String getActiveMDMBundle(){
-        if(activeMDMBundle == null){
+    public String getActiveMDMBundle() {
+        if (activeMDMBundle == null) {
 
             OMElement mdmPropertiesElement = documentElement.getFirstChildWithName(mobileConfElement)
                     .getFirstChildWithName(new QName("MDMProperties"));
 
             Iterator<OMElement> iterator = mdmPropertiesElement.getChildElements();
-            while (iterator.hasNext()){
+            while (iterator.hasNext()) {
                 OMElement mdmElement = iterator.next();
-                if(getMDMConfigs().get(ACTIVE_MDM).equals(mdmElement.getAttributeValue(new QName("name")))){
-                    return activeMDMBundle =  mdmElement.getAttributeValue(new QName("bundle"));
+                if (getMDMConfigs().get(ACTIVE_MDM).equals(mdmElement.getAttributeValue(new QName("name")))) {
+                    return activeMDMBundle = mdmElement.getAttributeValue(new QName("bundle"));
                 }
             }
         }
 
         return activeMDMBundle;
     }
-
-
 
 
 }


### PR DESCRIPTION
## Purpose
> In a distributed setup, if we install an iOS application via IoTS store it won’t install the application. In order to get 'plist', the device tries to reach IoTS through an inaccessible port.  

## Goals
> This fix changes the port retrieving logic when the device tries to get 'plist. It has used carbon properties to retrieve port, instead of carbon properties used system properties to get the correct port. 

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK -1.8
> databases - MySQL

## Learning
> N/A