### PR TITLE
Correctly initialize TinyMCE editor with the initial content

### DIFF
--- a/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/themes/appm/js/logic/inline-editor.js
+++ b/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/themes/appm/js/logic/inline-editor.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
                      theme_advanced_toolbar_location : "top",
                      theme_advanced_toolbar_align : "left",
                      theme_advanced_resizing : true,
-                     init_instance_callback: loadDefaultTinyMCEContent()
+                     init_instance_callback: "loadDefaultTinyMCEContent"
 
                  });
     
@@ -18,7 +18,7 @@ $(document).ready(function() {
 });
 
 
-function loadDefaultTinyMCEContent() {
+function loadDefaultTinyMCEContent(tinyMCEEditor) {
 	
     var provider = $("#provider").val();
     var apiName  = $("#webapp").val();
@@ -38,7 +38,7 @@ function loadDefaultTinyMCEContent() {
 	                var docContent = provider.content;
 
 	               $('#apiDeatils').empty().html('<p><h1> ' + docName + '</h1></p>');
-	               $('#inlineEditor').val(docContent);
+	               tinyMCEEditor.setContent(docContent);
 	               //tinyMCE.activeEditor.setContent(docContent);
 				 }
 				


### PR DESCRIPTION
## Purpose

Fixes #708 

## Goals
Document editor in the Publisher doesn't display the content of an In-line document inside the TinyMCE editor in some web browsers. This PR fixed it..

## Approach
- Correctly passes the 'after init callback' function to the `tinyMCE.init( )` function.
- Correctly setting the doc content to the editor by using the `setContent` function.

## Automation tests
 - Unit tests 
   No
 - Integration tests
   No

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
