### PR TITLE
Re-enabling tags in appm for mobile apps and fixing related bugs

### DIFF
--- a/components/org.wso2.carbon.appmgt.impl/src/main/java/org/wso2/carbon/appmgt/impl/APIConsumerImpl.java
+++ b/components/org.wso2.carbon.appmgt.impl/src/main/java/org/wso2/carbon/appmgt/impl/APIConsumerImpl.java
@@ -221,7 +221,8 @@ class APIConsumerImpl extends AbstractAPIManager implements APIConsumer {
                 PrivilegedCarbonContext.startTenantFlow();
                 PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
         	}
-            String resourceByTagQueryPath = RegistryConstants.QUERIES_COLLECTION_PATH + "/resource-by-tag";
+            String resourceByTagQueryPath = RegistryConstants.QUERIES_COLLECTION_PATH +
+                    "/resource-by-tag-appm";
             Map<String, String> params = new HashMap<String, String>();
             params.put("1", tag);
             if (AppMConstants.WEBAPP_ASSET_TYPE.equals(assetType) || AppMConstants.SITE_ASSET_TYPE.equals(assetType)){

--- a/components/org.wso2.carbon.appmgt.impl/src/main/java/org/wso2/carbon/appmgt/impl/AbstractAPIManager.java
+++ b/components/org.wso2.carbon.appmgt.impl/src/main/java/org/wso2/carbon/appmgt/impl/AbstractAPIManager.java
@@ -117,7 +117,7 @@ public abstract class AbstractAPIManager implements APIManager {
             throws RegistryException, AppManagementException {
         String tagsQueryPath = RegistryConstants.QUERIES_COLLECTION_PATH + "/tag-summary-appmgt";
         String latestAPIsQueryPath = RegistryConstants.QUERIES_COLLECTION_PATH + "/latest-apis";
-        String resourcesByTag = RegistryConstants.QUERIES_COLLECTION_PATH + "/resource-by-tag";
+        String resourcesByTag = RegistryConstants.QUERIES_COLLECTION_PATH + "/resource-by-tag-appm";
         String path = RegistryUtils.getAbsolutePath(RegistryContext.getBaseInstance(),
                                                     RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH + "/repository/components/org.wso2.carbon.governance");
         if (username == null) {

--- a/components/org.wso2.carbon.appmgt.impl/src/main/java/org/wso2/carbon/appmgt/impl/AbstractAPIManager.java
+++ b/components/org.wso2.carbon.appmgt.impl/src/main/java/org/wso2/carbon/appmgt/impl/AbstractAPIManager.java
@@ -119,7 +119,7 @@ public abstract class AbstractAPIManager implements APIManager {
         String latestAPIsQueryPath = RegistryConstants.QUERIES_COLLECTION_PATH + "/latest-apis";
         String resourcesByTag = RegistryConstants.QUERIES_COLLECTION_PATH + "/resource-by-tag-appm";
         String path = RegistryUtils.getAbsolutePath(RegistryContext.getBaseInstance(),
-                                                    RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH + "/repository/components/org.wso2.carbon.governance");
+                RegistryConstants.GOVERNANCE_REGISTRY_BASE_PATH + "/repository/components/org.wso2.carbon.governance");
         if (username == null) {
             try {
                 UserRealm realm = ServiceReferenceHolder.getUserRealm();

--- a/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/apis/v1/asset_api_router.jag
+++ b/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/apis/v1/asset_api_router.jag
@@ -1755,7 +1755,6 @@ require('/modules/publisher.js').exec(function(ctx) {
  **/
 
 function addTags(tags, assetId, rxtManager, type) {
-   /*
     //Only proceed if there are any tags
     if (tags.length == 0) {
         log.debug("No tags to add to asset with id " +assetId);
@@ -1771,7 +1770,6 @@ function addTags(tags, assetId, rxtManager, type) {
 
     //Attach the tags
     rxtManager.registry.tag(path, tags);
-    */
 }
 
 /**
@@ -1782,7 +1780,7 @@ function addTags(tags, assetId, rxtManager, type) {
  @type - apptype e.g mobileapp
  **/
 function updateTags(newTags, assetId, rxtManager, type) {
-    /*
+
     //Obtain the artifact
     var artifactManager = rxtManager.getArtifactManager(type);
     var asset = artifactManager.get(assetId);
@@ -1795,7 +1793,6 @@ function updateTags(newTags, assetId, rxtManager, type) {
     //add New Tags
     addTags(newTags, assetId, rxtManager, type);
     log.debug("Tags added visibility");
-    */
 }
 
 

--- a/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/themes/mobileapp/partials/add-mobileapp.hbs
+++ b/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/themes/mobileapp/partials/add-mobileapp.hbs
@@ -124,10 +124,10 @@
                 </div>
             </div>
 
-            <div id="control-packagename"	class="form-group">
+            <div id="control-packagename" class="form-group">
                 <label class="control-label col-sm-2">Tags</label>
                 <div class="col-sm-10">
-                    <input type="text" id="txtTags" name="tags"  class='col-lg-6 col-sm-8 col-xs-6'
+                    <input type="text" id="txtTags" name="tags" class='col-lg-6 col-sm-8 col-xs-6'
                            placeholder="type tag to search"/>
                 </div>
             </div>

--- a/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/themes/mobileapp/partials/add-mobileapp.hbs
+++ b/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/themes/mobileapp/partials/add-mobileapp.hbs
@@ -124,6 +124,14 @@
                 </div>
             </div>
 
+            <div id="control-packagename"	class="form-group">
+                <label class="control-label col-sm-2">Tags</label>
+                <div class="col-sm-10">
+                    <input type="text" id="txtTags" name="tags"  class='col-lg-6 col-sm-8 col-xs-6'
+                           placeholder="type tag to search"/>
+                </div>
+            </div>
+
             <div class="form-group">
                 <label class="control-label col-sm-2" for="txtBanner">Banner  <span style="color:#FF0000">*</span><br><small>(705px * 344px, .png)</small></label>
                 <div class="col-sm-10">

--- a/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/themes/mobileapp/partials/edit-mobileapp.hbs
+++ b/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/themes/mobileapp/partials/edit-mobileapp.hbs
@@ -94,10 +94,10 @@
                 </div>
             </div>
 
-            <div id="control-packagename"	class="form-group">
+            <div id="control-packagename" class="form-group">
                 <label class="control-label col-sm-2">Tags</label>
                 <div class="col-sm-10">
-                    <input type="text" id="txtTags" name="tags"  class='col-lg-6 col-sm-8 col-xs-6'
+                    <input type="text" id="txtTags" name="tags" class='col-lg-6 col-sm-8 col-xs-6'
                            placeholder="type tag to search"/>
                 </div>
             </div>

--- a/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/themes/mobileapp/partials/edit-mobileapp.hbs
+++ b/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/themes/mobileapp/partials/edit-mobileapp.hbs
@@ -101,7 +101,6 @@
                            placeholder="type tag to search"/>
                 </div>
             </div>
-			
 
 			<div class="form-group">
                 <label class="control-label col-sm-2" for="txtBanner">Banner  <span style="color:#FF0000">*</span><br><small>(705px * 344px, .png)</small></label>

--- a/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/themes/mobileapp/partials/edit-mobileapp.hbs
+++ b/features/org.wso2.carbon.appmgt.publisher.feature/src/main/resources/publisher/themes/mobileapp/partials/edit-mobileapp.hbs
@@ -94,6 +94,14 @@
                 </div>
             </div>
 
+            <div id="control-packagename"	class="form-group">
+                <label class="control-label col-sm-2">Tags</label>
+                <div class="col-sm-10">
+                    <input type="text" id="txtTags" name="tags"  class='col-lg-6 col-sm-8 col-xs-6'
+                           placeholder="type tag to search"/>
+                </div>
+            </div>
+			
 
 			<div class="form-group">
                 <label class="control-label col-sm-2" for="txtBanner">Banner  <span style="color:#FF0000">*</span><br><small>(705px * 344px, .png)</small></label>

--- a/features/org.wso2.carbon.appmgt.store.feature/src/main/resources/store/extensions/assets/mobileapp/themes/store/renderers/extensions/assets/mobileapp/pages/asset.js
+++ b/features/org.wso2.carbon.appmgt.store.feature/src/main/resources/store/extensions/assets/mobileapp/themes/store/renderers/extensions/assets/mobileapp/pages/asset.js
@@ -3,7 +3,6 @@ var render = function(theme, data, meta, require) {
 	
 	var images = data.asset.attributes.images_screenshots.split(",");
 	data.asset.attributes.images_screenshots = images;
-        data.header.hideFavouriteMenu = true;
 
     var searchQuery =  data.search.query;
     if(typeof(searchQuery) != typeof({})){

--- a/features/org.wso2.carbon.appmgt.store.feature/src/main/resources/store/extensions/assets/mobileapp/themes/store/renderers/extensions/assets/mobileapp/pages/assets.js
+++ b/features/org.wso2.carbon.appmgt.store.feature/src/main/resources/store/extensions/assets/mobileapp/themes/store/renderers/extensions/assets/mobileapp/pages/assets.js
@@ -2,7 +2,7 @@ var render = function (theme, data, meta, require) {
 
 
     data.header.config = data.config;
-    data.header.hideFavouriteMenu = true;
+
 
     var searchQuery =  data.search.query;
     if(typeof(searchQuery) != typeof({})){

--- a/features/org.wso2.carbon.appmgt.store.feature/src/main/resources/store/extensions/assets/mobileapp/themes/store/renderers/extensions/assets/mobileapp/pages/subscriptions.js
+++ b/features/org.wso2.carbon.appmgt.store.feature/src/main/resources/store/extensions/assets/mobileapp/themes/store/renderers/extensions/assets/mobileapp/pages/subscriptions.js
@@ -6,7 +6,6 @@ var render = function (theme, data, meta, require) {
     var storeObj = jagg.module("manager").getAPIStoreObj();
 
     var enabledTypeList = storeObj.getEnabledAssetTypeList();
-    data.header.hideFavouriteMenu = true;
     data.tags.tagUrl = "/assets/mobileapp";
     if(data.userAssets){
 

--- a/features/org.wso2.carbon.appmgt.store.feature/src/main/resources/store/themes/store/partials/left-column.hbs
+++ b/features/org.wso2.carbon.appmgt.store.feature/src/main/resources/store/themes/store/partials/left-column.hbs
@@ -77,7 +77,7 @@ its own partion sinceit does not support tags--}}
 </nav>
 
 {{!-- left-column - tags --}}
-<div class="add-margin-top-3x hidden-xs hidden-sm hidden" style="{{#if hideTag}}display: none{{/if}}">
+<div class="add-margin-top-3x hidden-xs hidden-sm" style="{{#if hideTag}}display: none{{/if}}">
     <div class="section-title"> {{t "Tags"}}</div>
     {{#if tags}}
         <ul class="tags">


### PR DESCRIPTION
## Purpose
> Currently, adding/viewing tags has been disabled in appm, this will reintroduce tags.

## Goals
> Reverting commits related to disabling tags, fixing other related issues.

## Approach
> Following commits were reverted: 
https://github.com/wso2/carbon-appmgt/commit/9f9469fb7da17f2f8207b10f69295c58dc31966e  
https://github.com/wso2/carbon-appmgt/commit/45bb26091ff795d3578dc295524d9aa4f82013ba

APPM and APIM have been referring to the same location to store/access tags, due to this, there were problems encountered during the retrieval process. with this change, we are now storing APPM tags in an alternate location which is : /repository/components/org.wso2.carbon.registry/queries/resource-by-tag-appm

## User stories
> N/A

## Release note
> Re-enabling tags in appm for mobile apps and fixing related bugs

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A