### PR TITLE
Adding missing fields,when calling the publisher API.

### DIFF
--- a/components/org.wso2.carbon.appmgt.rest.api.publisher/src/main/java/org/wso2/carbon/appmgt/rest/api/publisher/utils/mappings/APPMappingUtil.java
+++ b/components/org.wso2.carbon.appmgt.rest.api.publisher/src/main/java/org/wso2/carbon/appmgt/rest/api/publisher/utils/mappings/APPMappingUtil.java
@@ -511,6 +511,8 @@ public class APPMappingUtil {
         dto.setCreatedtime(mobileApp.getDisplayName());
         dto.setBanner(mobileApp.getBanner());
         dto.setRecentChanges(mobileApp.getRecentChanges());
+        dto.setLifecycleState(mobileApp.getLifeCycleStatus().getStatus());
+        dto.setProvider(mobileApp.getAppProvider());
 
         AppAppmetaDTO appAppmetaDTO = new AppAppmetaDTO();
         appAppmetaDTO.setPackage(mobileApp.getPackageName());


### PR DESCRIPTION
When calling the publisher API with the "field-filter=all" option instead of "field-filter=basic",There are some more information, but loosing: provider and lifecycleState.

This will resolve that issue and added those missing fields.
